### PR TITLE
Rename module-xrdp-pipewire into module-xrdp

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pipewire versions 0.3.58 and later are supported.
 
 # Files
 ## Sources
-- [src/module-xrdp-pipewire.c](src/module-xrdp-pipewire.c)
+- [src/module-xrdp.c](src/module-xrdp.c)
     The module source.
 - [src/pw-cli_0358_mod.c](src/pw-cli_0358_mod.c)
     pw-cli for older systems running pipewire 0.3.58

--- a/instfiles/load_pw_modules.sh
+++ b/instfiles/load_pw_modules.sh
@@ -14,7 +14,7 @@ if [ -n "$XRDP_SESSION" -a -n "$XRDP_SOCKET_PATH" ]; then
     done
 
     # Kill module, if it is working
-    #PID=$(ps -u $(id -u) -o pid,ruser,cmd | grep libpipewire-module-xrdp-pipewire | grep -v grep | sed -e 's/^ *//' | cut -d' ' -f1)
+    #PID=$(ps -u $(id -u) -o pid,ruser,cmd | grep libpipewire-module-xrdp | grep -v grep | sed -e 's/^ *//' | cut -d' ' -f1)
     #if [ -n "$PID" ]; then
     #    kill -HUP $PID
     #fi
@@ -44,11 +44,11 @@ if [ -n "$XRDP_SESSION" -a -n "$XRDP_SOCKET_PATH" ]; then
     QUANTUMVAL2=$(($QUANTUMVAL * 2))
 
     # enable both xrdp-sink ans xrdp-source
-    $PWCLI -m -d load-module libpipewire-module-xrdp-pipewire sink.node.latency=$QUANTUMVAL sink.stream.props={node.name=xrdp-sink} source.stream.props={node.name=xrdp-source} > /dev/null &
+    $PWCLI -m -d load-module libpipewire-module-xrdp sink.node.latency=$QUANTUMVAL sink.stream.props={node.name=xrdp-sink} source.stream.props={node.name=xrdp-source} > /dev/null &
     # enable xrdp-sink only
-    # $PWCLI -m -d load-module libpipewire-module-xrdp-pipewire sink.node.latency=$QUANTUMVAL sink.stream.props={node.name=xrdp-sink} > /dev/null &
+    # $PWCLI -m -d load-module libpipewire-module-xrdp sink.node.latency=$QUANTUMVAL sink.stream.props={node.name=xrdp-sink} > /dev/null &
     # enable xrdp-source only
-    # $PWCLI -m -d load-module libpipewire-module-xrdp-pipewire source.stream.props={node.name=xrdp-source} > /dev/null &
+    # $PWCLI -m -d load-module libpipewire-module-xrdp source.stream.props={node.name=xrdp-source} > /dev/null &
 
     sleep 1
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,13 +5,13 @@ if USE_ALT_PW_CLI
 pkglibexec_PROGRAMS = pw-cli_0358_mod
 endif
 
-modlibexec_LTLIBRARIES = libpipewire-module-xrdp-pipewire.la
+modlibexec_LTLIBRARIES = libpipewire-module-xrdp.la
 
 # _GNU_SOURCE needed for asprintf() declaration
 pw_cli_0358_mod_SOURCES = pw-cli_0358_mod.c
 pw_cli_0358_mod_CFLAGS =  $(PW_CFLAGS) $(SPA_CFLAGS) -D_GNU_SOURCE
 pw_cli_0358_mod_LDFLAGS = $(PW_LIBS)
 
-libpipewire_module_xrdp_pipewire_la_SOURCES = module-xrdp-pipewire.c
-libpipewire_module_xrdp_pipewire_la_CFLAGS = $(PW_CFLAGS) $(SPA_CFLAGS) -fPIC
-libpipewire_module_xrdp_pipewire_la_LDFLAGS = -module -avoid-version
+libpipewire_module_xrdp_la_SOURCES = module-xrdp.c
+libpipewire_module_xrdp_la_CFLAGS = $(PW_CFLAGS) $(SPA_CFLAGS) -fPIC
+libpipewire_module_xrdp_la_LDFLAGS = -module -avoid-version

--- a/src/module-xrdp.c
+++ b/src/module-xrdp.c
@@ -132,7 +132,7 @@
  *\endcode
  */
 
-#define NAME "xrdp-pipewire"
+#define NAME "xrdp"
 
 #define DEFAULT_FORMAT "S16"
 #define DEFAULT_RATE 44100


### PR DESCRIPTION
The pipewire suffix is redundant, so we drop it.

In practice, what this commit does:

1) Rename the source file from module-xrdp-pipewire.c to module-xrdp.c,
   thus we're in line with the naming scheme for modules in the pipewire
   source tree:

```
$ ls <pipewire-git-tree>/src/modules
flatpak-utils.h
meson.build
module-access.c
module-adapter
module-adapter.c
[...]
```

2) Rename the library that is built, from
   libpipewire-module-xrdp-pipewire.so to libpipewire-module-xrdp.so,
   once again to be in line with the naming scheme used by pipewire
   upstream:

```
$ ls -1 /usr/lib/x86_64-linux-gnu/pipewire-0.3/
libpipewire-module-access.so
libpipewire-module-adapter.so
libpipewire-module-avb.so
libpipewire-module-client-device.so
libpipewire-module-client-node.so
```

This change is cosmetic, it doesn't fix any known issue.