### PR TITLE
load_pw_modules: Make it no-op if no pw-cli or pipewire is not running

### DIFF
--- a/instfiles/load_pw_modules.sh
+++ b/instfiles/load_pw_modules.sh
@@ -1,10 +1,19 @@
 #!/bin/sh
 
+if ! command -v pw-cli >/dev/null; then
+    echo "pw-cli not found, exiting"
+    exit 0
+fi
+
+if ! pw-cli quit 2>/dev/null; then
+    echo "pipewire server is not running, exiting"
+    exit 0
+fi
+
 status=0
 
 if [ -n "$XRDP_SESSION" -a -n "$XRDP_SOCKET_PATH" ]; then
-    # These values are not present on xrdp versions before v0.9.8
-
+    # Destroy xrdp sink and source if they already exist
     OBJECT_IDS=$(pw-cli ls Node | sed -e "s/^[^a-z]//" | grep -w "^id" | sed -e "s/^[^0-9]*//" -e "s/[^0-9]/-/" | cut -d- -f1)
     for OBJECT_ID in $OBJECT_IDS; do
         NODE_NAME=$(pw-cli info $OBJECT_ID | grep -w "node\.name" | cut -d\" -f2)


### PR DESCRIPTION
With this change, the script exits gracefully if ever it runs on a system where pipewire is not installed or not running.

Note that 'pw-cli quit' was added in pipewire 0.3.38, so we're good since we require 0.3.58 at least.

While we're here, we also drop a stray comment (it comes from load_pa_modules.sh, however the code associated with this comment is gone, cf. [1]), and we replace it by a comment to explain what the next code block does.

[1]: https://github.com/neutrinolabs/pulseaudio-module-xrdp/blob/791dc3f95cd099adb1075708fb46069e0c1257bb/instfiles/load_pa_modules.sh#L6-L13